### PR TITLE
add secrets AWS creds so GH actions can run tests

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -31,6 +31,8 @@ jobs:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.BROKAMP_PM25_READ_ONLY_AWS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.BROKAMP_PM25_READ_ONLY_AWS_KEY_SECRET }}
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
I added the read only access keys to our organization secrets.  These should be available to GH actions now.